### PR TITLE
Accept numbers and strings for relationship id

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "as-array": "^1.0.0",
     "es6-promise": "^2.3.0",
+    "is-number": "^2.0.2",
     "join-path": "^1.0.0",
     "lodash": "^3.10.0",
     "pluralize": "^1.1.2",

--- a/src/serialize/format-request-relationships.js
+++ b/src/serialize/format-request-relationships.js
@@ -1,5 +1,6 @@
-import _, {map, isNumber} from 'lodash';
+import _, {map} from 'lodash';
 import pluralize from 'pluralize';
+import isNumber from 'is-number';
 
 function formatRequestRelationships (relationships) {
 
@@ -12,7 +13,7 @@ function formatRequestRelationships (relationships) {
         return [name, {
           data: {
             type: pluralize(name, 2),
-            id: data
+            id: Number(data)
           }
         }];
       }
@@ -23,7 +24,7 @@ function formatRequestRelationships (relationships) {
             if (isNumber(val)) {
               return {
                 type: pluralize(name, 2),
-                id: val
+                id: Number(val)
               };
             }
             else {

--- a/test/resource.js
+++ b/test/resource.js
@@ -261,7 +261,7 @@ test.creating('new', ({equal, context}) => {
     });
 });
 
-test.creating('with relationships', ({context, equal}) => {
+test.creating('with relationships', ({context, deepEqual}) => {
 
   return context.projects
     .createProject({
@@ -278,7 +278,7 @@ test.creating('with relationships', ({context, equal}) => {
 
         let req = mockFetch.request();
 
-        equal(req.body, JSON.stringify({
+        deepEqual(JSON.parse(req.body), {
           data: {
             type: 'projects',
             attributes: {
@@ -299,7 +299,39 @@ test.creating('with relationships', ({context, equal}) => {
               }
             }
           }
-        }), 'body');
+        }, 'request body');
+      });
+});
+
+test.creating('relationship with id as a string', function ({context, deepEqual}) {
+
+  return context.projects
+    .createProject({
+      title: 'My Project'
+    })
+    .relatedTo({
+      project: '123'
+    })
+      .then((res) => {
+
+        let req = mockFetch.request();
+
+        deepEqual(JSON.parse(req.body), {
+          data: {
+            type: 'projects',
+            attributes: {
+              title: 'My Project'
+            },
+            relationships: {
+              project: {
+                data: {
+                  type: 'projects',
+                  id: 123
+                }
+              }
+            }
+          }
+        }, 'request body');
       });
 });
 


### PR DESCRIPTION
`123` and `"123"` should work.

Lodash's `isNumber()` method doesn't do enough checking, so using the `is-number` NPM module instead
